### PR TITLE
Fix handling of YMenuBar and YMenuButton

### DIFF
--- a/lib/yui_rest_client/version.rb
+++ b/lib/yui_rest_client/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module YuiRestClient
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
   API_VERSION = 'v1'
 end

--- a/lib/yui_rest_client/widgets/menucollection.rb
+++ b/lib/yui_rest_client/widgets/menucollection.rb
@@ -4,13 +4,14 @@ module YuiRestClient
   module Widgets
     # Class representing a menucollection in UI. It can be YMenuButton, YMenuBar.
     class Menucollection < Widgets::Base
-      # Sends action to click on one item of a menu (menu button or menu bar) in UI.
-      # @param item [String] value to select from menu.
-      # @example Click button with label 'test_button' for menucollection with id 'test_id'.
+      # Sends action to click one item of a menu (menu button or menu bar) in UI.
+      # @param path [String] value to select from menu.
+      # @example Click menu item with label 'sub_menu_item' for menucollection
+      # with id 'test_id'.
       # @example
-      #   app.menucollection(id: 'test_id').click('test_item')
-      def click(item)
-        action(action: Actions::PRESS, value: item)
+      #   app.menucollection(id: 'test_id').click('menu_item|sub_menu_item')
+      def click(path)
+        action(action: Actions::SELECT, value: path)
       end
 
       # Returns the list of items available to select from widget.

--- a/spec/unit/widgets/table_spec.rb
+++ b/spec/unit/widgets/table_spec.rb
@@ -7,19 +7,19 @@ module YuiRestClient
     RSpec.describe Table do
       let(:widget_controller) { instance_double('widget_controller') }
       let(:filter) { FilterExtractor.new({ id: 'foo' }) }
-      let(:header_0) { 'header_0' }
-      let(:header_1) { 'header_1' }
-      let(:headers) { [header_0, header_1] }
-      let(:cell_0_0) { 'cell_0_0' }
-      let(:cell_1_0) { 'cell_1_0' }
-      let(:row_0) { [cell_0_0, '', '', ''] }
-      let(:row_1) { [cell_1_0, '', '', ''] }
-      let(:rows) { [row_0, row_1] }
+      let(:header0) { 'header0' }
+      let(:header1) { 'header1' }
+      let(:headers) { [header0, header1] }
+      let(:cell0) { 'cell0' }
+      let(:cell1) { 'cell1' }
+      let(:row0) { [cell0, '', '', ''] }
+      let(:row1) { [cell1, '', '', ''] }
+      let(:rows) { [row0, row1] }
       let(:table_with_rows) do
         double('Response', { body: [{ header: headers,
                                       items: [
-                                        { labels: row_0 },
-                                        { labels: row_1, selected: true }
+                                        { labels: row0 },
+                                        { labels: row1, selected: true }
                                       ] }] })
       end
       subject { Table.new(widget_controller, filter) }
@@ -55,14 +55,14 @@ module YuiRestClient
         end
         context 'when column is provided' do
           it 'sends select action' do
-            expect(subject).to receive(:action).with({ action: 'select', value: cell_0_0, column: 0 })
-            expect(subject.select(value: cell_0_0, column: header_0)).to equal(subject)
+            expect(subject).to receive(:action).with({ action: 'select', value: cell0, column: 0 })
+            expect(subject.select(value: cell0, column: header0)).to equal(subject)
           end
         end
         context 'when column is not provided' do
           it 'sends select action' do
-            expect(subject).to receive(:action).with({ action: 'select', value: cell_0_0 })
-            expect(subject.select(value: cell_0_0)).to equal(subject)
+            expect(subject).to receive(:action).with({ action: 'select', value: cell0 })
+            expect(subject.select(value: cell0)).to equal(subject)
           end
         end
         context 'when row is provided' do
@@ -73,14 +73,14 @@ module YuiRestClient
         end
         context 'when value and row are provided' do
           it 'sends select action using row' do
-            expect(subject).to receive(:action).with({ action: 'select', value: cell_0_0 })
-            expect(subject.select(value: cell_0_0, row: 0)).to equal(subject)
+            expect(subject).to receive(:action).with({ action: 'select', value: cell0 })
+            expect(subject.select(value: cell0, row: 0)).to equal(subject)
           end
         end
       end
 
       describe '#selected_items' do
-        let(:rows_selected) { [row_1] }
+        let(:rows_selected) { [row1] }
         it 'lists selected items' do
           allow(widget_controller).to receive(:find).and_return(table_with_rows)
           expect(subject.selected_items).to eql(rows_selected)

--- a/spec/widgets/button_spec.rb
+++ b/spec/widgets/button_spec.rb
@@ -13,7 +13,7 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:press_existing_button) { stub_post.with(query_id_press) }
-      let(:press_non_existent_button) { stub_post_404.with(query_id_press) }
+      let(:press_non_existent_button) { stub_post404.with(query_id_press) }
       let(:get_enabled_button) { stub_get_id.to_return(button_enabled) }
       let(:get_disabled_button) { stub_get_id.to_return(disabled_widget) }
 
@@ -42,7 +42,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.button(id).debug_label }.to raise_error(Error::WidgetNotFoundError)
           end
         end
@@ -65,7 +65,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.button(id).enabled? }.to raise_error(Error::WidgetNotFoundError)
           end
         end
@@ -79,7 +79,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.button(id).fkey }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/checkbox_spec.rb
+++ b/spec/widgets/checkbox_spec.rb
@@ -16,11 +16,11 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:toggle_existing_checkbox) { stub_post.with(query_toggle) }
-      let(:toggle_non_existent_checkbox) { stub_post_404.with(query_toggle) }
+      let(:toggle_non_existent_checkbox) { stub_post404.with(query_toggle) }
       let(:check_existing_checkbox) { stub_post.with(query_check) }
-      let(:check_non_existent_checkbox) { stub_post_404.with(query_check) }
+      let(:check_non_existent_checkbox) { stub_post404.with(query_check) }
       let(:uncheck_existing_checkbox) { stub_post.with(query_uncheck) }
-      let(:uncheck_non_existent_checkbox) { stub_post_404.with(query_uncheck) }
+      let(:uncheck_non_existent_checkbox) { stub_post404.with(query_uncheck) }
       let(:get_checked_checkbox) { stub_get_id.to_return(checked_checkbox) }
       let(:get_unchecked_checkbox) { stub_get_id.to_return(unchecked_checkbox) }
 
@@ -89,7 +89,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.checkbox(id).checked? }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/combobox_spec.rb
+++ b/spec/widgets/combobox_spec.rb
@@ -17,7 +17,7 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:select_item_in_existing_combobox) { stub_post.with(query_select) }
-      let(:select_item_in_non_existent_combobox) { stub_post_404.with(query_select) }
+      let(:select_item_in_non_existent_combobox) { stub_post404.with(query_select) }
       let(:get_items) { stub_get_id.to_return(items_body) }
 
       describe '#select' do
@@ -45,7 +45,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.combobox(id).items }.to raise_error(Error::WidgetNotFoundError)
           end
         end
@@ -60,7 +60,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.combobox(id).value }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/label_spec.rb
+++ b/spec/widgets/label_spec.rb
@@ -27,7 +27,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.label(id).text }.to raise_error(Error::WidgetNotFoundError)
           end
         end
@@ -50,7 +50,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.label(id).heading? }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/radiobutton_spec.rb
+++ b/spec/widgets/radiobutton_spec.rb
@@ -14,7 +14,7 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:select_existing_radiobutton) { stub_post.with(query_select) }
-      let(:select_non_existent_radiobutton) { stub_post_404.with(query_select) }
+      let(:select_non_existent_radiobutton) { stub_post404.with(query_select) }
       let(:get_selected_radiobutton) { stub_get_id.to_return(selected_radiobutton) }
       let(:get_deselected_radiobutton) { stub_get_id.to_return(deselected_radiobutton) }
 
@@ -51,7 +51,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.radiobutton(id).selected? }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/richtext_spec.rb
+++ b/spec/widgets/richtext_spec.rb
@@ -15,7 +15,7 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:click_link_in_existing_richtext) { stub_post.with(query_select) }
-      let(:click_link_in_non_existing_richtext) { stub_post_404.with(query_select) }
+      let(:click_link_in_non_existing_richtext) { stub_post404.with(query_select) }
       let(:get_text) { stub_get_id.to_return(text_from_label) }
 
       describe '#click_link' do
@@ -43,7 +43,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.richtext(id).text }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/table_spec.rb
+++ b/spec/widgets/table_spec.rb
@@ -16,7 +16,7 @@ module YuiRestClient
       # Stubbed Requests
       let(:get_header_table) { stub_get_id.to_return(table_header) }
       let(:select_row_in_existing_table) { stub_post.with(query_select) }
-      let(:select_row_in_non_existent_table) { stub_post_404.with(query_select) }
+      let(:select_row_in_non_existent_table) { stub_post404.with(query_select) }
       let(:request_query_value_column) { { value: 'test_row', column: 'header1' } }
 
       describe '#select' do

--- a/spec/widgets/textbox_spec.rb
+++ b/spec/widgets/textbox_spec.rb
@@ -14,7 +14,7 @@ module YuiRestClient
 
       # Stubbed Requests
       let(:set_text_existing_textbox) { stub_post.with(query_enter_text) }
-      let(:set_text_non_existent_textbox) { stub_post_404.with(query_enter_text) }
+      let(:set_text_non_existent_textbox) { stub_post404.with(query_enter_text) }
       let(:get_value) { stub_get_id.to_return(text_from_textbox) }
 
       describe '#set' do
@@ -42,7 +42,7 @@ module YuiRestClient
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
-            stub_get_id_404
+            stub_get_id404
             expect { @app.textbox(id).value }.to raise_error(Error::WidgetNotFoundError)
           end
         end

--- a/spec/widgets/widgets_common_spec.rb
+++ b/spec/widgets/widgets_common_spec.rb
@@ -23,10 +23,10 @@ RSpec.shared_context 'WidgetsCommon' do
   # Common Stubbed Requests
   # POST Stubs
   let(:stub_post) { stub_request(:post, widgets_url) }
-  let(:stub_post_404) { stub_post.to_return(status404) }
+  let(:stub_post404) { stub_post.to_return(status404) }
 
   # GET Stubs
   let(:stub_get) { stub_request(:get, widgets_url) }
   let(:stub_get_id) { stub_get.with(query_id) }
-  let(:stub_get_id_404) { stub_get_id.to_return(status404) }
+  let(:stub_get_id404) { stub_get_id.to_return(status404) }
 end


### PR DESCRIPTION
Correct action on server side is called `select` and not `press`, which
is available only for the buttons.