### PR TITLE
Test version bump only when gem has relevant changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Gem
 on:
   push:
+    paths-ignore:
+      - README.md
+      - '.github/**'
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
-name: Test
+name: Test with rspec and rubocop
 
 on: pull_request
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,10 +10,6 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2
-    - name: Check version file was changed
-      run: |
-        git fetch origin master
-        git --no-pager diff --name-only FETCH_HEAD `git merge-base FETCH_HEAD master` | grep version.rb
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test_version_bump.yml
+++ b/.github/workflows/test_version_bump.yml
@@ -1,0 +1,16 @@
+name: Test version bump
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check version file was changed if there are code changes
+      run: |
+        git fetch origin master
+        git --no-pager diff --name-only origin/master | grep version.rb


### PR DESCRIPTION
Currently CI fails if code has not been changed, e.g. changes just to
README file. Those are not published as a part of gem, so should not
fail CI and should not also trigger publishing.
With `paths-ignore` we can achieve this.
