### PR TITLE
Update url to the libyui-rest-api project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # YuiRestClient
 
 Ruby gem to interact with YaST applications via libyui-rest-api.
-See documentation of the [libyui-rest-api project](https://github.com/libyui/libyui-rest-api/)
+See documentation of the [libyui-rest-api project](https://github.com/libyui/libyui/tree/master/libyui-rest-api/doc)
 for more details about server side implementation.
 
 Usage example:


### PR DESCRIPTION
libyui-rest-api project was moved to single repo under libyui. Updating
url to the documentation in the new strcuture.